### PR TITLE
Corrige erro no retorno da operação para listagem de documentos do processo

### DIFF
--- a/rn/CguRN.php
+++ b/rn/CguRN.php
@@ -59,6 +59,7 @@ class CguRN extends InfraRN {
     	$dto->retDtaGeracaoProtocolo();
     	$dto->retStrStaProtocoloProtocolo();
     	$dto->retStrSinBloqueado();
+        $dto->retStrStaDocumento();
     	
     	$dto->retNumIdUnidadeGeradoraProtocolo();
     	$dto->retStrSiglaUnidadeGeradoraProtocolo();


### PR DESCRIPTION
Esse commit visa resolveu o erro 
```
Atributo [StaDocumento] não recebeu valor.: {"item":{"key":"infra_tipo_excecao","value":"INFRA_ERRO"}}
```
que ocorre quando é solicitada a listagem dos documentos de um dado processo SEI
